### PR TITLE
feat: Add more grammar resources and Irodori

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ If you are interested in contributing, **make a pull request**.
 - [Listening](#listening)
 - [Writing](#writing)
 - [Output](#output)
-- [Resource aggregators](#resource-aggregators)
-- [Miscellaneaous](#miscellaneaous)
+- [Resource Aggregators](#resource-aggregators)
+- [Miscellaneous](#miscellaneous)
 
 
 ## Learning guides


### PR DESCRIPTION
- Add Markdown version of Cure Dolly transcript.
- Add Wordrabbit and TUFS Japanese module's grammar explanation.
- Add Irodori: they have a lot of free audio files for their lessons.