### PR TITLE
Add KanjiDraw to Writing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Physically writing kanji is something you may or may not be interested in. Eithe
 - [Kankenbros](https://rentry.org/kankenbros) - The place to look at if you're interested in passing the 漢字検定, 'kanji kentei'.
 - [Basic Kanji Book 1](https://www.amazon.com/BASIC-KANJI-BOOK-Vol-1-2-C3-A8me-dp-4893589733/dp/4893589733/ref=dp_ob_title_bk) - If you really insist on using a textbook, this is good.
 - [Genki-Yoshi](https://github.com/FragozoLeonardo/Genki-Yoshi) - Software to automatically create 原稿用紙 to practice writing kana and kanji.
+- [KanjiDraw](https://kanjidraw.com) - Interactive and gamified kanji writing practice with stroke-order puzzles, guided and free drawing phases, and draw-to-find dictionary search.
 
 ## Output
 


### PR DESCRIPTION
Hello, Donkuri! 
KanjiDraw is a free browser tool for practicing kanji handwriting (with Wanikani levels). It uses KanjiVG stroke data and includes multiple drill phases (stroke puzzles, guided tracing, free drawing, multi-size). 

Fits the Writing section alongside Genki-Yoshi and Kanken deck — fills the gap for interactive browser-based writing practice.

Disclosure: I'm the author and it's a completely free app.