### PR TITLE
Add JIVX to the Output section

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Output is concerned with producing Japanese. It's about speaking and writing (no
 - [Slowly](https://slowly.app/) - A useful app to make Japanese-speaking penpals.
 - [HelloTalk](https://www.hellotalk.com/) - A popular language exchange app.
 - [italki](https://www.italki.com/) - A website meant to connect you with language tutors, potentially helping you with output.
+- [JIVX](https://jivx.com/) - A web app for output practice: you get an English prompt, type or speak the Japanese, and an AI grades it with corrections. JLPT-leveled sentences with audio; the N5 tier is free.
 
 ## Resource aggregators
 


### PR DESCRIPTION
Adds [JIVX](https://jivx.com) under **Output**.

**What it is:** output practice with grading — you get an English prompt, produce the Japanese by typing or speaking, and an AI grades it with corrections (grammar, vocab, register). 2,500 JLPT-leveled sentences (N5–N1), each with neutral/casual forms and audio; SRS scheduling built in. The N5 tier is free, no account needed for the demo.

**Why Output:** the section currently covers guides, exchange communities, and tutors — there's nothing that grades what you actually produce. This sits between "read the guide" and "talk to a human."

**Disclosure:** I built it. Happy to adjust the wording or placement however you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)